### PR TITLE
Add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ language: r
 warnings_are_errors: true
 sudo: required
 cache: packages
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,4 +12,6 @@ Imports:
     rstudioapi (>= 0.5),
     tidyr (>= 0.4)
 RoxygenNote: 5.0.1
-Suggests: testthat
+Suggests:
+    covr,
+    testthat

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Travis-CI Build Status](https://travis-ci.org/MangoTheCat/tidyshiny.svg?branch=master)](https://travis-ci.org/MangoTheCat/tidyshiny)
 [![](http://www.r-pkg.org/badges/version/tidyshiny)](http://www.r-pkg.org/pkg/tidyshiny)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/tidyshiny)](http://www.r-pkg.org/pkg/tidyshiny)
+[![Coverage Status](https://codecov.io/github/MangoTheCat/tidyshiny/coverage.svg?branch=master)](https://codecov.io/github/MangoTheCat/tidyshiny?branch=master)
 
 ## Installation
 


### PR DESCRIPTION
- Call on Travis
- Suggests covr in DESCRIPTION
- Badge in README

This is how it looks:
https://codecov.io/github/gaborcsardi/tidyshiny

Once you merge this PR, it will be here:
https://codecov.io/github/MangoTheCat/tidyshiny
Also linked from the badge in the README

Btw. you can declare that coverage calculation should ignore the shiny code, like this: https://github.com/jimhester/covr#exclusion-comments

Or you can try to test it with RSelenium, this would be great to try, anyway. :)
